### PR TITLE
Do not specify buildcache in colcon_defaults

### DIFF
--- a/.github/ci/colcon_defaults.yaml
+++ b/.github/ci/colcon_defaults.yaml
@@ -6,9 +6,6 @@
       "--no-warn-unused-cli",
       "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
       "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON",
-      # Use buildcache
-      "-DCMAKE_C_COMPILER_LAUNCHER=buildcache",
-      "-DCMAKE_CXX_COMPILER_LAUNCHER=buildcache",
       # BFD in conda is not compiled with fPIC
       "-DSTACK_DETAILS_AUTO_DETECT:BOOL=FALSE",
       "-DSTACK_DETAILS_BFD:BOOL=FALSE",

--- a/.github/workflows/pixi.yaml
+++ b/.github/workflows/pixi.yaml
@@ -32,6 +32,8 @@ jobs:
         run: |
           echo "BUILDCACHE_CC=x86_64-conda-linux-gnu-gcc" >> $GITHUB_ENV
           echo "BUILDCACHE_CXX=x86_64-conda-linux-gnu-g++" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=buildcache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=buildcache" >> $GITHUB_ENV
 
       - run: |
           pixi run build --cmake-args \


### PR DESCRIPTION
buildcache support is quite cool, but as the buildcache installation is not managed by pixi, it breaks just running `pixi run sync` && `pixi run colcon build` locally. In this PR I remove the setting of buildcache in colcon_defaults, and move it to the GitHub Actions yaml. After I added the environment variable (see https://cmake.org/cmake/help/v3.29/envvar/CMAKE_LANG_COMPILER_LAUNCHER.html#envvar:CMAKE_%3CLANG%3E_COMPILER_LAUNCHER), I noticed that we were adding the same values also via `--cmake-args` , but to be honest I do not know if that worked. 